### PR TITLE
Add GSSoC Label and Level for Auto labels assignment 

### DIFF
--- a/.github /workflows/auto-label.yml
+++ b/.github /workflows/auto-label.yml
@@ -6,25 +6,42 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   auto-label:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up labels
-        uses: octokit/request-action@v2
-        id: create-labels
-        with:
-          route: POST /repos/${{ github.repository }}/labels
-          mediaType: '{"previews":["symmetra"]}'
-          # We'll create labels one by one in script below
-
       - name: Create labels if missing and assign
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          #!/bin/bash
+          set -e
+
+          # Determine if it's issue or PR
+          if [ "${{ github.event_name }}" == "issues" ]; then
+            ISSUE_NUMBER=${{ github.event.issue.number }}
+            TITLE="${{ github.event.issue.title }}"
+            BODY="${{ github.event.issue.body }}"
+            CREATOR="${{ github.event.issue.user.login }}"
+          else
+            ISSUE_NUMBER=${{ github.event.pull_request.number }}
+            TITLE="${{ github.event.pull_request.title }}"
+            BODY="${{ github.event.pull_request.body }}"
+            CREATOR="${{ github.event.pull_request.user.login }}"
+          fi
+
+          echo "Number: $ISSUE_NUMBER"
+          echo "Title: $TITLE"
+          echo "Creator: $CREATOR"
+
           # Define labels and colors
           declare -A labels
           labels["Level 1 / Beginner"]="#7AE7FF"
@@ -32,7 +49,7 @@ jobs:
           labels["Level 3 / Advanced"]="#FF7F7F"
           labels["GSSoC 25"]="#6F42C1"
 
-          # Create labels if they don't exist
+          # Create labels if missing
           for label in "${!labels[@]}"; do
             response=$(curl -s -o /dev/null -w "%{http_code}" \
               -X POST \
@@ -41,31 +58,34 @@ jobs:
               https://api.github.com/repos/${GITHUB_REPOSITORY}/labels \
               -d "{\"name\":\"$label\",\"color\":\"${labels[$label]}\"}")
             if [[ "$response" == "422" ]]; then
-              echo "Label '$label' already exists, skipping."
+              echo "Label '$label' already exists."
             else
               echo "Label '$label' created."
             fi
           done
 
-          # Determine complexity based on title/body
-          TITLE="${{ github.event.issue.title || github.event.pull_request.title }}"
-          BODY="${{ github.event.issue.body || github.event.pull_request.body }}"
+          sleep 2  # Ensure labels are registered
 
-          LEVEL_LABEL=""
+          # Determine complexity label
+          LEVEL_LABEL="Level 3 / Advanced"
           if echo "$TITLE$BODY" | grep -iqE "typo|doc|readme|ui"; then
             LEVEL_LABEL="Level 1 / Beginner"
           elif echo "$TITLE$BODY" | grep -iqE "feature|bug|small"; then
             LEVEL_LABEL="Level 2 / Intermediate"
-          else
-            LEVEL_LABEL="Level 3 / Advanced"
           fi
 
-          # Assign labels to issue or PR
-          ISSUE_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
-          curl -s -X POST \
+          echo "Level label: $LEVEL_LABEL"
+
+          # Assign labels and creator
+          ASSIGN_RESPONSE=$(curl -s -w "%{http_code}" -o /dev/null \
+            -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/$ISSUE_NUMBER/labels \
-            -d "{\"labels\":[\"GSSoC 25\",\"$LEVEL_LABEL\"]}"
-          
-          echo "Labels assigned: GSSoC 25, $LEVEL_LABEL"
+            https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/$ISSUE_NUMBER \
+            -d "{\"labels\":[\"GSSoC 25\",\"$LEVEL_LABEL\"],\"assignees\":[\"$CREATOR\"]}")
+
+          if [[ "$ASSIGN_RESPONSE" == "200" ]]; then
+            echo "Labels and assignee successfully assigned: GSSoC 25, $LEVEL_LABEL"
+          else
+            echo "Failed to assign labels or assignee. Response code: $ASSIGN_RESPONSE"
+          fi

--- a/.github /workflows/auto-label.yml
+++ b/.github /workflows/auto-label.yml
@@ -1,0 +1,71 @@
+name: "Auto Create & Assign Labels"
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up labels
+        uses: octokit/request-action@v2
+        id: create-labels
+        with:
+          route: POST /repos/${{ github.repository }}/labels
+          mediaType: '{"previews":["symmetra"]}'
+          # We'll create labels one by one in script below
+
+      - name: Create labels if missing and assign
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Define labels and colors
+          declare -A labels
+          labels["Level 1 / Beginner"]="#7AE7FF"
+          labels["Level 2 / Intermediate"]="#FFAB70"
+          labels["Level 3 / Advanced"]="#FF7F7F"
+          labels["GSSoC 25"]="#6F42C1"
+
+          # Create labels if they don't exist
+          for label in "${!labels[@]}"; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/${GITHUB_REPOSITORY}/labels \
+              -d "{\"name\":\"$label\",\"color\":\"${labels[$label]}\"}")
+            if [[ "$response" == "422" ]]; then
+              echo "Label '$label' already exists, skipping."
+            else
+              echo "Label '$label' created."
+            fi
+          done
+
+          # Determine complexity based on title/body
+          TITLE="${{ github.event.issue.title || github.event.pull_request.title }}"
+          BODY="${{ github.event.issue.body || github.event.pull_request.body }}"
+
+          LEVEL_LABEL=""
+          if echo "$TITLE$BODY" | grep -iqE "typo|doc|readme|ui"; then
+            LEVEL_LABEL="Level 1 / Beginner"
+          elif echo "$TITLE$BODY" | grep -iqE "feature|bug|small"; then
+            LEVEL_LABEL="Level 2 / Intermediate"
+          else
+            LEVEL_LABEL="Level 3 / Advanced"
+          fi
+
+          # Assign labels to issue or PR
+          ISSUE_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          curl -s -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/$ISSUE_NUMBER/labels \
+            -d "{\"labels\":[\"GSSoC 25\",\"$LEVEL_LABEL\"]}"
+          
+          echo "Labels assigned: GSSoC 25, $LEVEL_LABEL"


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #18 

## Rationale for this change

This PR adds an **automatic label assignment workflow** for all newly created issues and pull requests.  
It ensures:

- Labels `Level 1 / Beginner`, `Level 2 / Intermediate`, `Level 3 / Advanced` and `GSSoC 25` are automatically created (if not already present) with proper colors.  
- Labels are assigned based on **title and body keywords** to indicate complexity/impact.  
- Works for both **issues and PRs**, simplifying contribution management.

This improves consistency, saves manual labeling effort, and helps track GSSoC contributions automatically.

## What changes are included in this PR?

- Added a new GitHub Actions workflow file:  
  `.github/workflows/auto-label.yml`  
- Logic to:
  - Create missing labels with predefined colors
  - Assign labels automatically to new issues and PRs
  - Determine complexity level (1/2/3) from title/body keywords
  - Always assign `GSSoC 25` label

## Are these changes tested?

- Workflow tested by creating **dummy issues and PRs** in a separate branch to ensure labels are automatically applied.  
- Verified that existing labels are not duplicated and colors match the defined scheme.

## Are there any user-facing changes?

- No direct user-facing changes.  
- Contributors will see labels applied automatically when they open an issue or PR.
